### PR TITLE
alguns ajustes

### DIFF
--- a/labefood/src/constants/index.js
+++ b/labefood/src/constants/index.js
@@ -1,3 +1,5 @@
+import axios from "axios"
+
 export const BASE_URL = 'https://us-central1-missao-newton.cloudfunctions.net'
 
 export const appName = "rappi4A"

--- a/labefood/src/pages/adressRegistration/index.js
+++ b/labefood/src/pages/adressRegistration/index.js
@@ -1,4 +1,7 @@
+import { useProtectPage } from "../../hooks/useProtectPage";
+
 export const AdressRegistrationPage = () =>{
+    useProtectPage();
     return(
         <h1>Adress Registration Page</h1>
     )

--- a/labefood/src/pages/signup/index.js
+++ b/labefood/src/pages/signup/index.js
@@ -1,7 +1,7 @@
 import LogoInvert from "../../img/logo-future-eats-invert.png";
 import { SignupContainer } from "./SignupStyled";
 import { useForm } from "../../hooks/use-form";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import axios from "axios";
 import * as Coordinator from "../../routes/coordinator";
 import { useNavigate } from "react-router-dom";
@@ -17,6 +17,7 @@ import {
   Input,
   Button,
 } from "@chakra-ui/react";
+import { BASE_URL } from "../../constants";
 
 export const SignupPage = () => {
   const navigate = useNavigate();
@@ -34,41 +35,49 @@ export const SignupPage = () => {
   const [isPasswordValid, setIsPasswordValid] = useState(true);
 
   //--- Estados para confirmação de senha, não vai para a requisição
-  const [isPasswordConfirmValid, setPasswordConfirmaValid] = useState(true);
+  const [isPasswordConfirmValid, setIsPasswordConfirmValid] = useState(true);
   const [passwordConfirm, setPasswordConfirm] = useState("");
 
   //---Lógica para o 'olho' da senha
-  const [showPassword, setShowPassword] = useState(true); //primeira senha
+  const [showPassword, setShowPassword] = useState(false); //primeira senha
   const handleClickEye = () => setShowPassword(!showPassword);
-  const [showPasswordConfirm, setShowPasswordConfirm] = useState(true); //segunda senha
-  const handleClickEyeConfirm = () => setShowPasswordConfirm(!showPasswordConfirm)
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false); //segunda senha
+  const handleClickEyeConfirm = () => setShowPasswordConfirm(!showPasswordConfirm);
 
   const handleSubmit = (event) => {
     event.preventDefault();
     //--- Testes de validação que retorna booleanos para usar nas mensagens de erro do form control...
     setIsEmailValid(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(form.email));
-    setIsNameValid(/[A-Z][a-z]* [A-Z][a-z]{2,}$/.test(form.name));
+    setIsNameValid(/[A-Za-z]* [A-Za-z]{2,}$/.test(form.name));
     setIsCpfValid(
       /([0-9]{2}[\.]?[0-9]{3}[\.]?[0-9]{3}[\/]?[0-9]{4}[-]?[0-9]{2})|([0-9]{3}[\.]?[0-9]{3}[\.]?[0-9]{3}[-]?[0-9]{2})/.test(
         form.cpf
       )
     );
-    setIsPasswordValid(/^[0-9]{6,8}$/.test(form.password));
-    setPasswordConfirmaValid(passwordConfirm === form.password ? true : false);
+    setIsPasswordValid(/.{6,}/.test(form.password));
+    setIsPasswordConfirmValid(passwordConfirm === form.password ? true : false);
 
     //--- Requisição para criar um novo cadastro
-    axios
-      .post(
-        `https://us-central1-missao-newton.cloudfunctions.net/rappi4A/signup`,
-        form
-      )
-      .then((response) => {
-        console.log(response);
-        Coordinator.goToAdressRegistration(navigate);
-      })
-      .catch((error) => console.log(error));
+    if (
+      isEmailValid &&
+      isNameValid &&
+      isCpfValid &&
+      isPasswordConfirmValid &&
+      isPasswordValid
+    ) {
+      axios
+        .post(`${BASE_URL}/rappi4A/signup`, form)
+        .then((response) => {
+          localStorage.setItem("token", response.data.token);
+          Coordinator.goToAdressRegistration(navigate);
+        })
+        .catch((error) => {
+          alert(
+            "Erro ao processar sua requisição: " + error.response.data.message
+          );
+        });
+    }
   };
-  
 
   return (
     <SignupContainer>
@@ -83,7 +92,7 @@ export const SignupPage = () => {
 
       <form onSubmit={handleSubmit}>
         <FormControl isInvalid={!isNameValid}>
-          <FormLabel>Nome</FormLabel>
+          <FormLabel>Nome*</FormLabel>
           <Input
             type="text"
             name="name"
@@ -95,13 +104,13 @@ export const SignupPage = () => {
           />
           {!isNameValid ? (
             <FormErrorMessage as="p">
-              Atenção: Nome e sobrenome
+              Atenção: Nome e sobrenome.
             </FormErrorMessage>
           ) : undefined}
         </FormControl>
 
         <FormControl isInvalid={!isEmailValid}>
-          <FormLabel>E mail</FormLabel>
+          <FormLabel>E mail*</FormLabel>
           <Input
             type="email"
             name="email"
@@ -117,9 +126,8 @@ export const SignupPage = () => {
         </FormControl>
 
         <FormControl isInvalid={!isCpfValid}>
-          <FormLabel>CPF</FormLabel>
+          <FormLabel>CPF*</FormLabel>
           <Input
-            type="number"
             name="cpf"
             placeholder="000.000.000-00"
             value={form.cpf}
@@ -133,7 +141,7 @@ export const SignupPage = () => {
         </FormControl>
 
         <FormControl isInvalid={!isPasswordValid}>
-          <FormLabel>Senha</FormLabel>
+          <FormLabel>Senha*</FormLabel>
           <InputGroup size="lg">
             <Input
               type={showPassword ? "text" : "password"}
@@ -144,7 +152,12 @@ export const SignupPage = () => {
               size="lg"
             />
             <InputRightElement height="100%" width="4.5rem">
-              <Button background="none" h="1.75rem" size="lg" onClick={handleClickEye}>
+              <Button
+                background="none"
+                h="1.75rem"
+                size="lg"
+                onClick={handleClickEye}
+              >
                 {showPassword ? <FaEyeSlash /> : <FaEye />}
               </Button>
             </InputRightElement>
@@ -157,7 +170,7 @@ export const SignupPage = () => {
         </FormControl>
 
         <FormControl isInvalid={!isPasswordConfirmValid}>
-          <FormLabel>Confirmar</FormLabel>
+          <FormLabel>Confirmar*</FormLabel>
           <InputGroup size="lg">
             <Input
               type={showPasswordConfirm ? "text" : "password"}
@@ -169,7 +182,12 @@ export const SignupPage = () => {
               required
             />
             <InputRightElement height="100%" width="4.5rem">
-              <Button background="none" h="1.75rem" size="lg" onClick={handleClickEyeConfirm}>
+              <Button
+                background="none"
+                h="1.75rem"
+                size="lg"
+                onClick={handleClickEyeConfirm}
+              >
                 {showPasswordConfirm ? <FaEyeSlash /> : <FaEye />}
               </Button>
             </InputRightElement>


### PR DESCRIPTION
Não consegui achar uma forma de fazer a requisição entrar só depois da validação do formulário.

Na verdade a única forma que achei possível, seria setando o estado de tudo para false, mas daí o formulário renderizaria com todos os avisos de erro da validação.

Vou tentar ajuda no próximo plantão.

no mais, eu só adicionei a mensagem de alerta para quando o cpf ou email já está cadastrado, mudei o formato da senha para aceitar outros caracteres e não só números, mudei o  input do cpf para aceitar com pontuação e o do nome eu mudei para aceitar tanto maiúsculas quanto minúsculas, coloquei para guardar o token e chamei o useProtect na página de cadastro de endereço.
