### PR TITLE
fix: bug de clicar 2 vezes para cadastrar

### DIFF
--- a/labefood/src/pages/signup/index.js
+++ b/labefood/src/pages/signup/index.js
@@ -29,20 +29,29 @@ export const SignupPage = () => {
   });
 
   //--- Estados com valores booleanos para a validação do dados preenchidos no form
-  const [isEmailValid, setIsEmailValid] = useState(true);
-  const [isNameValid, setIsNameValid] = useState(true);
-  const [isCpfValid, setIsCpfValid] = useState(true);
-  const [isPasswordValid, setIsPasswordValid] = useState(true);
+  const [isEmailValid, setIsEmailValid] = useState(undefined);
+  const [isNameValid, setIsNameValid] = useState(undefined);
+  const [isCpfValid, setIsCpfValid] = useState(undefined);
+  const [isPasswordValid, setIsPasswordValid] = useState(undefined);
 
   //--- Estados para confirmação de senha, não vai para a requisição
   const [isPasswordConfirmValid, setIsPasswordConfirmValid] = useState(false);
   const [passwordConfirm, setPasswordConfirm] = useState("");
-  const [aux, setAux] = useState(false)
 
   useEffect(() => {
+    //testes do formulário para não enviar o cadastro incompleto
     setIsPasswordConfirmValid(passwordConfirm === form.password ? true : false)
     setIsPasswordValid(true)
-  },[passwordConfirm, form.password, onchange])
+    setIsEmailValid(form.email === "" ? 'true' : /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(form.email));
+    setIsNameValid(form.name === "" ? 'true' : /[A-Za-z]* [A-Za-z]{2,15}$/.test(form.name));
+    setIsCpfValid(form.cpf === "" ? 'true' :
+    /^(\d{3})(\d{3})(\d{3})(\d{2})$/.test(
+        form.cpf
+      )
+    );
+    setIsPasswordValid(form.password === "" ? 'true' : /^.{6,15}$/.test(form.password));
+    setIsPasswordConfirmValid(passwordConfirm === form.password ? true : false);
+  },[form, passwordConfirm])
 
   //---Lógica para o 'olho' da senha
   const [showPassword, setShowPassword] = useState(false); //primeira senha
@@ -52,33 +61,13 @@ export const SignupPage = () => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    //--- Testes de validação que retorna booleanos para usar nas mensagens de erro do form control...
-    setIsEmailValid(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/.test(form.email));
-    setIsNameValid(/[A-Za-z]* [A-Za-z]{2,}$/.test(form.name));
-    setIsCpfValid(
-      /([0-9]{2}[\.]?[0-9]{3}[\.]?[0-9]{3}[\/]?[0-9]{4}[-]?[0-9]{2})|([0-9]{3}[\.]?[0-9]{3}[\.]?[0-9]{3}[-]?[0-9]{2})/.test(
-        form.cpf
-      )
-    );
-    setIsPasswordValid(/^.{6,15}$/.test(form.password));
-    setIsPasswordConfirmValid(passwordConfirm === form.password ? true : false);
 
-if (
-  isEmailValid &&
-  isNameValid &&
-  isCpfValid &&
-  isPasswordValid &&
-  isPasswordConfirmValid
-) {
-  setAux(true)
-}
   if (
     isEmailValid &&
     isNameValid &&
     isCpfValid &&
     isPasswordValid &&
-    isPasswordConfirmValid &&
-    aux
+    isPasswordConfirmValid
   ) {
      //--- Requisição para criar um novo cadastro
     axios
@@ -131,7 +120,7 @@ if (
           onChange={onChange}
           showPassword={showPassword}
           handleClick={handleClickEye}
-          errorMessage={"Formato de senha inválido."}
+          errorMessage={"Mínimo de 6 caracteres..."}
         />
 
         <PasswordInput

--- a/labefood/src/pages/signup/index.js
+++ b/labefood/src/pages/signup/index.js
@@ -131,7 +131,7 @@ export const SignupPage = () => {
           onChange={(e) => setPasswordConfirm(e.target.value)}
           showPassword={showPasswordConfirm}
           handleClick={handleClickEyeConfirm}
-          errorMessage={"Senha nâo Confere"}
+          errorMessage={"Deve ser a mesma que a anterior!"}
         />
 
         <Button type="submit" colorScheme="red" variant="solid">


### PR DESCRIPTION
Tirei o bug de clicar 2 vezes no botão para cadastrar.
Só que daí ele acompanha a validação do input em tempo real, conforme vai digitando

Mexi no regx do CPF tmbm, agora ele não passa mais da quantidade de dígitos

Acho que ficou melhor,.... mas daí vcs vêem se preferem assim ou do jeto que tava antes mesmo

A única coisa que não consegui tirar foi o espaço que não aceita no final do nome